### PR TITLE
fix: handle self-closing tags

### DIFF
--- a/zeep-lib/src/model/helpers_content.rs
+++ b/zeep-lib/src/model/helpers_content.rs
@@ -1,3 +1,13 @@
+/// Default for XSD simple-type text wrappers (e.g. `<value>` from a
+/// `#[yaserde(text = true)]` field) when the element is present but empty
+/// (self-closing, e.g. `<foo/>`). Without an explicit default, yaserde treats
+/// the field as missing and deserialization fails with "required field" even
+/// though the element was there (it just had no text content).
+#[allow(dead_code)]
+fn __yaserde_default_string() -> String {
+    String::new()
+}
+
 pub mod error {
     #![allow(dead_code)]
 

--- a/zeep-lib/src/model/structures/writer.rs
+++ b/zeep-lib/src/model/structures/writer.rs
@@ -106,14 +106,16 @@ where
     }
     writeln!(writer, "pub struct {rust_name} {{")?;
     if rust_type.is_string() {
-        writeln!(writer, "    #[yaserde(text = true)]")?;
+        // `default` covers the case where the element is present but empty
+        // (e.g. `<foo/>`)
+        writeln!(writer, "    #[yaserde(text = true, default = \"__yaserde_default_string\")]")?;
         writeln!(writer, "    pub value: {rust_type}")?;
     } else if rust_type.is_other() {
         writeln!(writer, "    #[yaserde(flatten = true)]")?;
         writeln!(writer, "    pub value: {rust_type}")?;
     } else {
         // note: flatten is not supported for other types
-        writeln!(writer, "    #[yaserde(text = true)]")?;
+        writeln!(writer, "    #[yaserde(text = true, default = \"__yaserde_default_string\")]")?;
         writeln!(writer, "    pub value: String")?;
     }
     writeln!(writer, "}}")?;
@@ -251,7 +253,7 @@ mod tests {
 
     #[test]
     fn can_write_a_simple_type_to_rust() {
-        const EXPECTED: &str = "/// A person\n#[derive(Debug, Default, YaSerialize, YaDeserialize)]\npub struct Person {\n    #[yaserde(text = true)]\n    pub value: String\n}\nimpl restrictions::CheckRestrictions for Person {\n  fn check_restrictions(&self, restrictions: Option<Rc<restrictions::Restrictions>>) -> error::SoapResult<()>  {\n     self.value.check_restrictions(restrictions)\n  }\n}\n";
+        const EXPECTED: &str = "/// A person\n#[derive(Debug, Default, YaSerialize, YaDeserialize)]\npub struct Person {\n    #[yaserde(text = true, default = \"__yaserde_default_string\")]\n    pub value: String\n}\nimpl restrictions::CheckRestrictions for Person {\n  fn check_restrictions(&self, restrictions: Option<Rc<restrictions::Restrictions>>) -> error::SoapResult<()>  {\n     self.value.check_restrictions(restrictions)\n  }\n}\n";
         let mut writer = Vec::new();
         let props = prep_simple_props(None);
         let rust_type = RustType::Simple(props);

--- a/zeep-lib/src/yaserde_tests/mod.rs
+++ b/zeep-lib/src/yaserde_tests/mod.rs
@@ -1,5 +1,9 @@
 use yaserde_derive::{YaDeserialize, YaSerialize};
 
+fn empty_string() -> String {
+    String::new()
+}
+
 #[derive(Debug, Default, YaSerialize, YaDeserialize)]
 #[yaserde(prefix = "ex", namespaces = {"ex" = "http://example.com"}, rename = "Person")]
 struct Person {
@@ -19,4 +23,23 @@ fn can_write_a_struct_type_with_namespace_to_rust() {
 
     let expected = r#"<?xml version="1.0" encoding="UTF-8"?><ex:Person xmlns:ex="http://example.com"><ex:name>John</ex:name><ex:age>42</ex:age></ex:Person>"#;
     assert_eq!(xml, expected);
+}
+
+// Mirrors the `#[yaserde(text = true, default = "__yaserde_default_string")]`
+// pattern the generator emits for XSD simple-type text wrappers (see
+// `write_type_alias` in `model/structures/writer.rs`). Some SOAP services
+// send self-closing elements like `<foobar />`
+// for optional-content fields; xml-rs emits no `Characters` event for those,
+// so without an explicit default, deserializing a *present but empty*
+// element fails with a spurious "required field" error.
+#[derive(Debug, Default, YaSerialize, YaDeserialize)]
+struct TextWrapper {
+    #[yaserde(text = true, default = "empty_string")]
+    pub value: String,
+}
+
+#[test]
+fn can_deserialize_self_closing_element_into_text_wrapper() {
+    let parsed: TextWrapper = yaserde::de::from_str("<TextWrapper/>").unwrap();
+    assert_eq!(parsed.value, "");
 }


### PR DESCRIPTION
Hi,
This MR handles SOAP returns with self-closing tags. We set them to null.
Cheers