### PR TITLE
fix: don't prepend namespace prefix unless specified

### DIFF
--- a/zeep-lib/src/model/doc.rs
+++ b/zeep-lib/src/model/doc.rs
@@ -21,6 +21,8 @@ pub struct RustDocument {
     pub(crate) namespaces: Vec<Rc<Namespace>>,
     pub(crate) target_namespaces: Vec<Rc<Namespace>>,
     pub(crate) current_target_namespace: Option<Rc<Namespace>>,
+    pub(crate) element_form_qualified: HashMap<String, bool>,
+    pub(crate) attribute_form_qualified: HashMap<String, bool>,
     pub(crate) nodes: Vec<Rc<RustNode>>,
     pub(crate) soap_messages: Vec<Rc<SoapMessage>>,
     pub(crate) soap_ports: Vec<Rc<SoapPort>>,
@@ -42,6 +44,9 @@ impl RustDocument {
         extend_no_duplicates(&mut self.namespaces, other.namespaces);
         extend_no_duplicates(&mut self.target_namespaces, other.target_namespaces);
 
+        self.element_form_qualified.extend(other.element_form_qualified);
+        self.attribute_form_qualified.extend(other.attribute_form_qualified);
+
         self.nodes.extend(other.nodes);
         self.soap_messages.extend(other.soap_messages);
         self.soap_ports.extend(other.soap_ports);
@@ -55,6 +60,8 @@ impl RustDocument {
             namespaces: Vec::new(),
             target_namespaces: Vec::new(),
             current_target_namespace: None,
+            element_form_qualified: HashMap::new(),
+            attribute_form_qualified: HashMap::new(),
             nodes: Vec::new(),
             soap_messages: Vec::new(),
             soap_ports: Vec::new(),
@@ -136,6 +143,29 @@ impl RustDocument {
             self.namespaces.push(tns.clone());
             self.current_target_namespace = Some(tns);
         }
+    }
+
+    /// Records whether locally-declared elements/attributes in the given
+    /// schema (identified by its target namespace) are namespace-qualified
+    /// by default. Per the XSD spec, `elementFormDefault`/`attributeFormDefault`
+    /// both default to "unqualified" when absent from the `<xs:schema>` element,
+    /// meaning only globally-declared (top-level) elements/attributes are
+    /// namespace-qualified. Locally-declared ones (e.g. fields nested inside
+    /// a complexType's sequence) must NOT carry a namespace prefix unless the
+    /// schema opts in.
+    pub fn set_form_defaults(&mut self, namespace: &str, elements_qualified: bool, attributes_qualified: bool) {
+        self.element_form_qualified
+            .insert(namespace.to_string(), elements_qualified);
+        self.attribute_form_qualified
+            .insert(namespace.to_string(), attributes_qualified);
+    }
+
+    pub fn elements_qualified_by_default(&self, namespace: &str) -> bool {
+        self.element_form_qualified.get(namespace).copied().unwrap_or(false)
+    }
+
+    pub fn attributes_qualified_by_default(&self, namespace: &str) -> bool {
+        self.attribute_form_qualified.get(namespace).copied().unwrap_or(false)
     }
 
     pub fn find_node_by_xml_name<'n>(

--- a/zeep-lib/src/model/field.rs
+++ b/zeep-lib/src/model/field.rs
@@ -40,6 +40,36 @@ impl<'n> TryFromNode<'n> for Field {
         target_namespace.clone_from(&doc.current_target_namespace);
 
         let is_attribute = node.tag_name().name() == "attribute";
+
+        // A locally-declared element/attribute (i.e. one nested inside a
+        // complexType, as opposed to a global declaration directly under
+        // `<xs:schema>`) is only namespace-qualified when the enclosing
+        // schema opts in via `elementFormDefault`/`attributeFormDefault`, or
+        // when this particular element/attribute has an explicit `form`
+        // override.
+        // Per the XSD spec both defaults are "unqualified".
+        let is_qualified = match node.attribute("form") {
+            Some("qualified") => true,
+            Some("unqualified") => false,
+            // A field node carrying its own explicit `targetNamespace` (rather
+            // than inheriting one from an enclosing `<xs:schema>`) is always
+            // qualified.
+            // This pattern is used for synthesized/global
+            // references (e.g. SOAP header parts), not schema-local fields
+            // subject to `elementFormDefault`.
+            _ if node.attribute("targetNamespace").is_some() => true,
+            _ => target_namespace.as_ref().is_some_and(|ns| {
+                if is_attribute {
+                    doc.attributes_qualified_by_default(&ns.namespace)
+                } else {
+                    doc.elements_qualified_by_default(&ns.namespace)
+                }
+            }),
+        };
+        if !is_qualified {
+            target_namespace = None;
+        }
+
         let parent_is_optional = node.parent().and_then(|n| n.attribute("minOccurs")) == Some("0");
         let is_nillable = node.attribute("nillable") == Some("true");
         let is_optional = if is_attribute {

--- a/zeep-lib/src/reader.rs
+++ b/zeep-lib/src/reader.rs
@@ -275,6 +275,11 @@ impl XmlReader {
         // Switch to the schema's target namespace if it has one
         if let Some(target_namespace) = node.attribute("targetNamespace") {
             doc.switch_to_target_namespace(target_namespace);
+            doc.set_form_defaults(
+                target_namespace,
+                node.attribute("elementFormDefault") == Some("qualified"),
+                node.attribute("attributeFormDefault") == Some("qualified"),
+            );
         }
 
         for child in node.children() {
@@ -397,6 +402,59 @@ mod tests {
         assert_eq!(
             target_namespace.as_ref().unwrap().namespace,
             "http://schemas.microsoft.com/exchange/services/2006/messages"
+        );
+    }
+
+    #[test]
+    fn locally_declared_fields_are_unqualified_unless_opted_in() {
+        // Regression test: per the XSD spec, elementFormDefault/attributeFormDefault
+        // default to "unqualified" when absent from <xs:schema>, so locally-declared
+        // fields (nested inside a complexType) must not carry a namespace prefix
+        // unless the schema opts in via elementFormDefault/attributeFormDefault, or
+        // the field itself has an explicit `form="qualified"` override.
+        const XSD: &str = include_str!("../test-data/unqualified-form-default.xsd");
+        let mut files = Files::new("types.xsd", XSD);
+        let nodes = XmlReader::read_xml_internal("types.xsd", &mut files).unwrap().nodes;
+        assert_eq!(nodes.len(), 1);
+        let node = nodes.first().unwrap();
+        let RustType::Complex(props) = &node.rust_type else {
+            panic!()
+        };
+
+        let ComplexProps { fields, .. } = &**props;
+        assert_eq!(fields.len(), 3);
+
+        let id_field = fields.iter().find(|f| f.xml_name == "Id").unwrap();
+        assert!(id_field.target_namespace.is_none());
+
+        let attr_field = fields.iter().find(|f| f.xml_name == "Attr").unwrap();
+        assert!(attr_field.target_namespace.is_none());
+
+        // Explicit `form="qualified"` overrides the schema-level default.
+        let qualified_field = fields.iter().find(|f| f.xml_name == "Qualified").unwrap();
+        assert_eq!(
+            qualified_field.target_namespace.as_ref().unwrap().namespace,
+            "http://schemas.microsoft.com/exchange/services/2006/types"
+        );
+    }
+
+    #[test]
+    fn locally_declared_fields_are_qualified_when_form_default_is_qualified() {
+        // single-complex.xsd sets elementFormDefault="qualified", so locally-declared
+        // elements should inherit the schema's target namespace.
+        const XSD: &str = include_str!("../test-data/single-complex.xsd");
+        let mut files = Files::new("types.xsd", XSD);
+        let nodes = XmlReader::read_xml_internal("types.xsd", &mut files).unwrap().nodes;
+        let node = nodes.first().unwrap();
+        let RustType::Complex(props) = &node.rust_type else {
+            panic!()
+        };
+
+        let ComplexProps { fields, .. } = &**props;
+        let id_field = fields.iter().find(|f| f.xml_name == "Id").unwrap();
+        assert_eq!(
+            id_field.target_namespace.as_ref().unwrap().namespace,
+            "http://schemas.microsoft.com/exchange/services/2006/types"
         );
     }
 

--- a/zeep-lib/test-data/unqualified-form-default.xsd
+++ b/zeep-lib/test-data/unqualified-form-default.xsd
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<xs:schema id="types"
+           xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types"
+           targetNamespace="http://schemas.microsoft.com/exchange/services/2006/types"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:complexType name="InstalledAppType">
+        <xs:sequence minOccurs="0">
+            <xs:element name="Id" type="xs:string" minOccurs="0"/>
+            <xs:element name="Qualified" type="xs:string" minOccurs="0" form="qualified"/>
+        </xs:sequence>
+        <xs:attribute name="Attr" type="xs:string"/>
+    </xs:complexType>
+</xs:schema>


### PR DESCRIPTION
Hi,
This MR makes it so that the locally declared elements are namespace unqualified by default
Thanks and cheers